### PR TITLE
quad_gantry_level: do not calibrate by default

### DIFF
--- a/configuration/macros.cfg
+++ b/configuration/macros.cfg
@@ -18,7 +18,7 @@ gcode:
     M190 S{bed_temp}                  ; Wait for bed to reach temperature
     M109 S{extruder_temp}             ; Set and wait for nozzle to reach temperature
     M107                              ; turn print fan off
-    QUAD_GANTRY_LEVEL CALIBRATE=false PARK=false
+    QUAD_GANTRY_LEVEL PARK=false
     M109 S{extruder_temp}             ; Set and wait for nozzle to reach temperature
     clean_nozzle                      ; clean nozzle
     CALIBRATE_Z
@@ -45,3 +45,4 @@ gcode:
     G90                            ; absolute positioning
     G0 X150 Y150 Z{Z} F12000       ; move to center
     RESTORE_GCODE_STATE NAME=PARKCENTER_state
+

--- a/configuration/probing.cfg
+++ b/configuration/probing.cfg
@@ -49,6 +49,10 @@ gcode:
   #####  set default  #####
   {% set park = params.PARK|default('true') %}
   #####  end of definitions  #####
+  # home all axes if not already
+  {% if "xyz" not in printer.toolhead.homed_axes %}
+    _CG28
+  {% endif %}
   SAVE_GCODE_STATE NAME=STATE_QUAD_GANTRY_LEVEL
   _SET_ACC VAL=HOME
   _SET_CURRENT VAL=HOME

--- a/configuration/probing.cfg
+++ b/configuration/probing.cfg
@@ -58,7 +58,7 @@ gcode:
   {% endif %}
   ATTACH_PROBE 
   QUAD_GANTRY_LEVEL_BASE
-  {% if params.CALIBRATE|default('true') == 'true' %}
+  {% if params.CALIBRATE|default('false') == 'true' %}
     CALIBRATE_Z RESET_SETTINGS=false
   {% else %}
     DETACH_PROBE
@@ -571,3 +571,4 @@ gcode:
   {% else %}
     {action_respond_info("PROBE_ACCEPT: Executed while PROBE_CALIBRATE is not running")}
   {% endif %}
+


### PR DESCRIPTION
make CALIBRATE_Z after QUAD_GANTRY_LEVEL opt-in