### PR TITLE
Clarify probe_switch_x/y description in config

### DIFF
--- a/configuration/z_calibration.cfg
+++ b/configuration/z_calibration.cfg
@@ -6,8 +6,8 @@
 #   Z endstop.
 probe_nozzle_x: 206
 probe_nozzle_y: 300
-#   The X and Y coordinates (in mm) for clicking the probe's switch
-#   on the Z endstop.
+#   The X and Y coordinates (in mm) for clicking the body of the probe's
+#   switch on the Z endstop.
 probe_switch_x: 211
 probe_switch_y: 281
 #   The X and Y coordinates (in mm) for probing on the print surface


### PR DESCRIPTION
Numerous users have mistakenly configured it to touch the Z endstop with the plunger of the switch instead of the body. Although it is mentioned in the readme, having it spelled out in the config comments would reduce confusion.