### PR TITLE
Improve docs for switch_offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ bed_xy_position: default from relative_reference_index of bed_mesh
 #   configured.
 switch_offset:
 #   The trigger point offset of the used mag-probe switch.
+#   Larger values will position the nozzle closer to the bed.
 #   This needs to be fined out manually. More on this later
 #   in this section..
 max_deviation: 1.0


### PR DESCRIPTION
Add an extra line of documentation for `switch_offset` that should help reduce confusion that seems commonly reported in Voron discord.