### PR TITLE
If the offset is too large, dock the probe before raising an error condition

### DIFF
--- a/z_calibration.py
+++ b/z_calibration.py
@@ -286,6 +286,7 @@ class CalibrationState:
             z_positions = [p[2] for p in positions]
             if max(z_positions) - min(z_positions) > self.helper.tolerance:
                 if retries >= self.helper.retries:
+                    self.helper.end_gcode.run_gcode_from_command()
                     raise self.gcmd.error("Probe samples exceed tolerance")
                 self.gcmd.respond_info("Probe samples exceed tolerance."
                                        " Retrying...")

--- a/z_calibration.py
+++ b/z_calibration.py
@@ -352,6 +352,7 @@ class CalibrationState:
                                   switch_zero, probe_zero, offset))
         # check max deviation
         if abs(offset) > self.helper.max_deviation:
+            self.helper.end_gcode.run_gcode_from_command()
             raise self.helper.printer.command_error("Offset is larger as"
                                                     " allowed: OFFSET=%.3f"
                                                     " MAX_DEVIATION=%.3f"


### PR DESCRIPTION
When the calculated offset is higher than the threshold, the script raises an error and aborts, leaving the probe attached to the toolhead. This is not a safe condition, and on printers like the V2.4, it is not easily recognized by the operator as the probe is under and behind the toolhead.

The change stows the probe before raising the error, leaving the printer in a safe condition.