### PR TITLE
Always treat clearance as an absolute value

### DIFF
--- a/z_calibration.py
+++ b/z_calibration.py
@@ -147,7 +147,7 @@ class ZCalibrationHelper:
         pos = toolhead.get_position()
         if pos[2] < self.clearance:
             # no clearance, better to move up
-            self._move([None, None, pos[2] + self.clearance], lift_speed)
+            self._move([None, None, self.clearance], lift_speed)
         # move to z-endstop position
         self._move(list(self.nozzle_site), self.speed)
         pos = toolhead.get_position()
@@ -266,7 +266,7 @@ class CalibrationState:
         pos = self.toolhead.get_position()
         if pos[2] < self.helper.clearance:
             # no clearance, better to move up
-            self.helper._move([None, None, pos[2] + self.helper.clearance],
+            self.helper._move([None, None, self.helper.clearance],
                               self.helper.lift_speed)
         # move to position
         self.helper._move(list(site), self.helper.speed)


### PR DESCRIPTION
Rationale: current algorithm treats clearance as an absolute value when comparing current z position, but as a relative value when it comes to moving the head up: if pos_z < clearance
  move(pos_z + clearance)

This kind of makes sense when the head is all the way down on the bed:  if 0 < 20 then move_to(20) Then the higher the head is, the less sense it makes: if 10 < 20 then move_to(30) In an extreme case (z at 19.9 and clearance is 20) it results in moving the head all the way up to 39.9!  At the same time if the head is already at 20, it's just kept at this height.

Basically, in my opinion the logic should be "if we are below the safe level, let's move up to that level to clear the things" rather than "if we are below the safe level, let's move up the additional safe level height".