### PR TITLE
Changes ./install.sh to allow for multiple klipper instances via kiauh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -94,6 +94,6 @@ done
 # Run steps
 verify_ready
 check_klipper
-#link_extension
-#remove_service
+link_extension
+remove_service
 restart_klipper

--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,7 @@ SRCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/ && pwd )"
 while getopts "k:n:" arg; do
     case $arg in
         k) KLIPPER_PATH=$OPTARG;;
-	n) NUM_INSTALLS=$OPTARG;;
+	    n) NUM_INSTALLS=$OPTARG;;
     esac
 done
 


### PR DESCRIPTION
The klipper service isn't named klipper.service when using kiauh and multiple printers on the same host.  This adds a -n flag to the install script to avoid issues with "klipper.service not found" and automates the restarting of the multiple instances.