### PR TITLE
fix: Signal multiple probes are coming

### DIFF
--- a/z_calibration.py
+++ b/z_calibration.py
@@ -420,6 +420,7 @@ class CalibrationState:
         # probe the probe-switch
         self.helper.switch_gcode.run_gcode_from_command()
         # probe the body of the switch
+        self.probe.multi_probe_begin()
         switch_zero = self._probe_on_site(self.z_endstop,
                                           self.helper.switch_site,
                                           check_probe=True)
@@ -428,6 +429,7 @@ class CalibrationState:
         probe_zero = self._probe_on_site(self.probe.mcu_probe,
                                          probe_site,
                                          check_probe=True)
+        self.probe.multi_probe_end()
         # calculate the offset
         offset = probe_zero - (switch_zero - nozzle_zero
                                + self.helper.switch_offset)


### PR DESCRIPTION
In many places related to probes, in the main Klipper code base, the 'multi_probe_begin()'/'multi_probe_end()' methods are used to tell the probe several samples are going to be taken.

For example, during bed mesh creation, a helper class is used to run the mesh probing.[1] This helper class uses the multi probe methods.[2]

This signalling to the probe that multiple probes are coming is important for modules that implement Klicky/dockable probe support. For example, this signalling can prevent mutliple attach/detach cycles.[3]

A similar result could be accomplished through the 'before_switch_gcode' config option but this commit removes the need for the user to do additional configuration and brings the behavior/implementation more in line with upstream Klipper probe handling.

[1]: https://github.com/Klipper3d/klipper/blob/039daec/klippy/extras/bed_mesh.py#L318
[2]: https://github.com/Klipper3d/klipper/blob/039daec/klippy/extras/probe.py#L437-L444
[3]: https://github.com/Klipper3d/klipper/pull/6247