### PR TITLE
fix: Use probe-manager for zero ref

### DIFF
--- a/z_calibration.py
+++ b/z_calibration.py
@@ -262,6 +262,9 @@ class ZCalibrationHelper:
             if (hasattr(mesh.bmc, 'zero_ref_pos')
                 and mesh.bmc.zero_ref_pos is not None):
                 return mesh.bmc.zero_ref_pos
+            elif (hasattr(mesh.bmc, 'probe_mgr')
+                and mesh.bmc.probe_mgr.zero_ref_pos is not None):
+                return mesh.bmc.probe_mgr.zero_ref_pos
             elif (hasattr(mesh.bmc, 'relative_reference_index')
                   and mesh.bmc.relative_reference_index is not None):
                 # TODO: remove: trying to read the deprecated rri


### PR DESCRIPTION
With recent changes to Klipper's probe.py, the location of some attributes has changed, in this case, the accessing of `[probe]` `zero_reference_position`.

Before this change, setting only the `[probe]` `zero_reference_position` and not passing `BED_POSITION` to `CALIBRATE_Z` or defining the config option, an error would be thrown saying "Cannot find the bed position!".