### PR TITLE
Add option to set the offsets via a custom macro

### DIFF
--- a/z_calibration.py
+++ b/z_calibration.py
@@ -53,6 +53,7 @@ class ZCalibrationHelper:
                                                       'before_switch_gcode',
                                                       '')
         self.end_gcode = gcode_macro.load_template(config, 'end_gcode', '')
+        self.set_offset_macro = config.get('offset_macro', None)
         self.query_endstops = self.printer.load_object(config,
                                                        'query_endstops')
         self.printer.register_event_handler("klippy:connect",
@@ -456,16 +457,20 @@ class CalibrationState:
         probe_site[1] -= probe_offsets[1]
         return probe_site
     def _set_new_gcode_offset(self, offset):
-        # reset gcode z offset to 0
-        gcmd_offset = self.gcode.create_gcode_command("SET_GCODE_OFFSET",
-                                                      "SET_GCODE_OFFSET",
-                                                      {'Z': 0.0})
-        self.gcode_move.cmd_SET_GCODE_OFFSET(gcmd_offset)
-        # set new gcode z offset
-        gcmd_offset = self.gcode.create_gcode_command("SET_GCODE_OFFSET",
-                                                      "SET_GCODE_OFFSET",
-                                                      {'Z_ADJUST': offset})
-        self.gcode_move.cmd_SET_GCODE_OFFSET(gcmd_offset)
+        if self.helper.set_offset_macro is not None:
+            self.gcmd.respond_info("%s: Using offset macro %s" % (self.gcmd.get_command(), self.helper.set_offset_macro))
+            self.gcode.run_script_from_command("{} Z={}".format(self.helper.set_offset_macro, offset))
+        else:
+            # reset gcode z offset to 0
+            gcmd_offset = self.gcode.create_gcode_command("SET_GCODE_OFFSET",
+                                                          "SET_GCODE_OFFSET",
+                                                          {'Z': 0.0})
+            self.gcode_move.cmd_SET_GCODE_OFFSET(gcmd_offset)
+            # set new gcode z offset
+            gcmd_offset = self.gcode.create_gcode_command("SET_GCODE_OFFSET",
+                                                          "SET_GCODE_OFFSET",
+                                                          {'Z_ADJUST': offset})
+            self.gcode_move.cmd_SET_GCODE_OFFSET(gcmd_offset)
     def calibrate_z(self, switch_offset, nozzle_site, switch_site, bed_site):
         # execute start gcode
         self.helper.start_gcode.run_gcode_from_command()


### PR DESCRIPTION
This PR adds a new config variable `offset_macro`.

When set to the name of a `gcode_macro`, instead of setting the calculated Z offset via `SET_GCODE_OFFSET` the configured macro is called with a parameter `Z` being set to the calculated offset value.

The reasoning behind this lies in toolchanging systems, in my case specifically Lineux: https://github.com/Bikin-Creative/Lineux-Toolchanger

For compensating any differences of the different tools in XYZ, all tools are measured against a common reference tool, most often T0.
Upon a toolchange to a different tool then `SET_GCODE_OFFSET` is used to adjust the motion system to the different nozzle position of the tool.
This in turn invalidates any changes made by klipper_z_calibration.

This PR now allows to:
* Measure all tools of the toolchanger against T0
* On each print, run `CALIBRATE_Z` for T0 calling a custom macro that lets the toolchanging code know about the new offset
* Have the toolchanging code apply the measure offset additionally to the measured tool offsets at each toolchange

Example macro for Lineux:
```
[gcode_macro Z_CALIBRATION_SET_OFFSET_MACRO]
gcode:
  {% set z_offset = params.Z|default(0.0)|float %}
  RESPOND MSG="Forwarding Z offset adjustment of {z_offset} to Lineux"
  SET_GCODE_VARIABLE MACRO=_btc_Variables VARIABLE=gcode_offset_z_adjust VALUE={z_offset}
  SET_GCODE_OFFSET Z_ADJUST={z_offset}
```

Lineux then runs
`SET_GCODE_OFFSET Z_ADJUST={printer["gcode_macro _btc_Variables"].gcode_offset_z_adjust} MOVE=1` on each toolchange.