### PR TITLE
fix: unwrap ProbeEndstopWrapper for probing_move on new Klipper

### DIFF
--- a/z_calibration.py
+++ b/z_calibration.py
@@ -494,9 +494,10 @@ class CalibrationState:
                                                   check_probe=True)
                 # probe bed position
                 probe_site = self._add_probe_offset(bed_site)
-                # Klipper's probe refactor (mid-2025) nests the real MCU
-                # endstop inside ProbeEndstopWrapper, which itself no longer
-                # exposes get_steppers/home_start/etc. Unwrap when needed.
+                # TODO: remove: deprecated since 2026-05-25
+                # Klipper's probe refactor nests the real MCU endstop inside
+                # ProbeEndstopWrapper, which itself no longer exposes
+                # get_steppers/home_start/etc. Unwrap when needed.
                 probe_endstop = self.probe.mcu_probe
                 if not hasattr(probe_endstop, 'get_steppers'):
                     probe_endstop = probe_endstop.mcu_endstop

--- a/z_calibration.py
+++ b/z_calibration.py
@@ -494,7 +494,13 @@ class CalibrationState:
                                                   check_probe=True)
                 # probe bed position
                 probe_site = self._add_probe_offset(bed_site)
-                probe_zero = self._probe_on_site(self.probe.mcu_probe,
+                # Klipper's probe refactor (mid-2025) nests the real MCU
+                # endstop inside ProbeEndstopWrapper, which itself no longer
+                # exposes get_steppers/home_start/etc. Unwrap when needed.
+                probe_endstop = self.probe.mcu_probe
+                if not hasattr(probe_endstop, 'get_steppers'):
+                    probe_endstop = probe_endstop.mcu_endstop
+                probe_zero = self._probe_on_site(probe_endstop,
                                                  probe_site,
                                                  check_probe=True)
             finally:


### PR DESCRIPTION
## Summary

Fixes `AttributeError: 'ProbeEndstopWrapper' object has no attribute 'get_steppers'` (reported in #176) seen on recent Klipper master.

## Root cause

Klipper's probe refactor — commits [`43baf9b8`](https://github.com/Klipper3d/klipper/commit/43baf9b8) ("probe: Use standard probe interface with DescendToEndstopHelper") and [`d92e9a38`](https://github.com/Klipper3d/klipper/commit/d92e9a38) ("probe: Simplify HomingViaProbeHelper") — restructured `ProbeEndstopWrapper`. The wrapper no longer exposes `get_steppers`, `add_stepper`, `home_start`, or `home_wait` directly; instead, the actual `MCU_endstop` is nested as `probe.mcu_probe.mcu_endstop`, and probing now goes through `DescendToEndstopHelper`.

`calibrate_z()` passes `self.probe.mcu_probe` straight to `phoming.probing_move()`, which then does `[es for es in endstops if es[0].get_steppers()]` in `HomingMove.__init__` (`homing.py:48`) — and crashes because the new wrapper lacks `get_steppers`.

## Fix

In `CalibrationState.calibrate_z`, detect whether the wrapper still exposes the endstop interface; if not, unwrap one level to `mcu_endstop`. Backwards-compatible with pre-refactor Klipper.

```python
probe_endstop = self.probe.mcu_probe
if not hasattr(probe_endstop, 'get_steppers'):
    probe_endstop = probe_endstop.mcu_endstop
```

The inner `mcu_endstop` already has Z steppers registered via `LookupZSteppers` in `DescendToEndstopHelper.__init__`, so `probing_move` accepts it without further setup. The `check_probe=True` path is unaffected because `ProbeEndstopWrapper.query_endstop` is still exposed.

## Test plan

- [ ] Run `CALIBRATE_Z` on current Klipper master — completes without `AttributeError`
- [ ] Run on older Klipper (pre-refactor) — still uses the wrapper directly via the `hasattr` short-circuit
- [ ] Verify the resulting Z offset matches a known-good reference